### PR TITLE
Standardise the issue template for JupyterHub repositories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ about: Create a report to help us repair something that is currently broken
 <!-- Tell us what you thought would happen. -->
 
 #### Actual behaviour
-<!-- Tell us what it actually happens. -->
+<!-- Tell us what actually happens. -->
 
 ### How to reproduce
 <!-- Use this section to describe the steps that a user would take to experience this bug. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,4 +30,4 @@ about: Create a report to help us repair something that is currently broken
  - Version:
  <!-- e.g. jupyterhub --version. --->
  - Configuration:
- <!-- Be careful not to share any sensible information. --->
+ <!-- Be careful not to share any sensitive information. --->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us repair something that is currently broken
+
+---
+<!-- Thank you for contributing. These HTML commments will not render in the issue, but you can delete them once you've read them if you prefer! -->
+
+### Bug description
+<!-- Use this section to clearly and concisely describe the bug. -->
+
+#### Expected behaviour
+<!-- Tell us what you thought would happen. -->
+
+#### Actual behaviour
+<!-- Tell us what it actually happens. -->
+
+### How to reproduce
+<!-- Use this section to describe the steps that a user would take to experience this bug. -->
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Your personal set up
+<!-- Tell us a little about the system you're using. -->
+
+ - OS:
+ <!-- [e.g. linux, OSX] -->
+ - Version:
+ <!-- e.g. jupyterhub --version. --->
+ - Configuration:
+ <!-- Be careful not to share any sensible information. --->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: "\U0001F914 All other questions, including if you're not sure what to do."
+    url: https://discourse.jupyter.org
+    about: Search on Discourse for similar questions or ask for help there.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,7 @@ about: Suggest a new feature or a big change
 
 
 ### Who would use this feature?
-<!-- Describe the audience for this feature. This information will affect who chooses to work on the feature with you. -->
+<!-- Describe who would benefit from using this feature. -->
 
 
 ### (Optional): Suggest a solution

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: "\U0001F680 Feature request"
+about: Suggest a new feature or a big change
+
+---
+<!-- Thank you for contributing. These HTML commments will not render in the issue, but you can delete them once you've read them if you prefer! -->
+
+### Proposed change
+<!-- Use this section to describe the feature you'd like to be added. -->
+
+
+### Alternative options
+<!-- Use this section to describe alternative options and why you've decided on the proposed feature above. -->
+
+
+### Who would use this feature?
+<!-- Describe the audience for this feature. This information will affect who chooses to work on the feature with you. -->
+
+
+### How much effort will adding it take?
+<!-- Try to estimate how much work adding this feature will require. This information will affect who chooses to work on the feature with you. -->
+
+
+### Who can do this work?
+<!-- What skills are needed? Who can be recruited to add this feature? This information will affect who chooses to work on the feature with you. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,7 +19,3 @@ about: Suggest a new feature or a big change
 
 ### (Optional): Suggest a solution
 <!-- Describe what you think needs to be done. This information will affect who chooses to work on the feature with you -->
-
-
-### Who can do this work?
-<!-- What skills are needed? Who can be recruited to add this feature? This information will affect who chooses to work on the feature with you. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,4 +18,4 @@ about: Suggest a new feature or a big change
 
 
 ### (Optional): Suggest a solution
-<!-- Describe what you think needs to be done. This information will affect who chooses to work on the feature with you -->
+<!-- Describe what you think needs to be done. Doing that is an excellent first step to get the feature implemented. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,8 +17,8 @@ about: Suggest a new feature or a big change
 <!-- Describe the audience for this feature. This information will affect who chooses to work on the feature with you. -->
 
 
-### How much effort will adding it take?
-<!-- Try to estimate how much work adding this feature will require. This information will affect who chooses to work on the feature with you. -->
+### (Optional): Suggest a solution
+<!-- Describe what you think needs to be done. This information will affect who chooses to work on the feature with you -->
 
 
 ### Who can do this work?

--- a/.github/support.yml
+++ b/.github/support.yml
@@ -10,9 +10,11 @@ supportComment: |
 
   I closed this issue because it was labelled as a support question.
 
-  Please repost this on the http://discourse.jupyter.org/ forum (most people who hang out here also hang out there, as well as more people).
-  We are trying to streamline the different discussion places and want to use the issues on GitHub repos for technical discussions on how to change the contents of the repo.
-  More general discussions should go to Discourse so that they are easier to find, better indexed by google and generally more accessible than being hidden in the bowels of a GitHub repository :smiley:
+  Please help us organize discussion by posting this on the http://discourse.jupyter.org/ forum.
+
+  Our goal is to sustain a positive experience for both users and developers. We use GitHub issues for specific discussions related to changing a repository's content, and let the forum be where we can more generally help and inspire each other.
+  
+  Thanks you for being an active member of our community! :heart:
 
   Thanks!
 

--- a/.github/support.yml
+++ b/.github/support.yml
@@ -10,7 +10,7 @@ supportComment: |
 
   I closed this issue because it was labelled as a support question.
 
-  Please repost this on the http://discourse.jupyter.org/ forum (where most of the people who hang out here also hang out, as well as more people).
+  Please repost this on the http://discourse.jupyter.org/ forum (most people who hang out here also hang out there, as well as more people).
   We are trying to streamline the different discussion places and want to use the issues on GitHub repos for technical discussions on how to change the contents of the repo.
   More general discussions should go to Discourse so that they are easier to find, better indexed by google and generally more accessible than being hidden in the bowels of a GitHub repository :smiley:
 

--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,0 +1,29 @@
+# Configuration for Support Requests - https://github.com/dessant/support-requests
+
+# Label used to mark issues as support requests
+supportLabel: support
+
+# Comment to post on issues marked as support requests, `{issue-author}` is an
+# optional placeholder. Set to `false` to disable
+supportComment: |
+  Hi there @{issue-author} :wave:!
+
+  I closed this issue because it was labelled as a support question.
+
+  Please repost this on the http://discourse.jupyter.org/ forum (where most of the people who hang out here also hang out, as well as more people).
+  We are trying to streamline the different discussion places and want to use the issues on GitHub repos for technical discussions on how to change the contents of the repo.
+  More general discussions should go to Discourse so that they are easier to find, better indexed by google and generally more accessible than being hidden in the bowls of a GitHub repository :smiley:
+
+  Thanks!
+
+# Close issues marked as support requests
+close: true
+
+# Lock issues marked as support requests
+lock: false
+
+# Assign `off-topic` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Repository to extend settings from
+# _extends: repo

--- a/.github/support.yml
+++ b/.github/support.yml
@@ -12,7 +12,7 @@ supportComment: |
 
   Please repost this on the http://discourse.jupyter.org/ forum (where most of the people who hang out here also hang out, as well as more people).
   We are trying to streamline the different discussion places and want to use the issues on GitHub repos for technical discussions on how to change the contents of the repo.
-  More general discussions should go to Discourse so that they are easier to find, better indexed by google and generally more accessible than being hidden in the bowls of a GitHub repository :smiley:
+  More general discussions should go to Discourse so that they are easier to find, better indexed by google and generally more accessible than being hidden in the bowels of a GitHub repository :smiley:
 
   Thanks!
 


### PR DESCRIPTION
This PR adds:
* An issue template to all JupyterHub repositories that don't have one already setup
(already in JupyterHub: https://github.com/jupyterhub/jupyterhub/issues/new/choose).
* A support bot that closes issues once they've been labeled as `support`
(checkout the bot in action here: https://github.com/manicstreetpreacher/test-bots).

Closes https://github.com/jupyterhub/team-compass/issues/271