### PR TITLE
Add request info bot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,12 +4,15 @@
 requestInfoReplyComment: |
   Hi there :wave:!
 
-  We would appreciate it if you could provide us with more info about this issue/PR.
-  A great way to start would be to follow the <a href="https://github.com/jupyterhub/.github/tree/master/.github/ISSUE_TEMPLATE">issue templates</a> or the repository
-  specific PR template (if any).
+  I noticed that this new issue/PR doesn't provide any description, so I labeled it with `needs-more-info`.
   
-  This helps people review your contribution and answer questions more quickly and also
-  helps people in the future who are looking for some quick context around this set of changes.
+  In order for us to be able to review your contribution and answer questions more quickly, please
+  describe it in more detail. A thorough description will also help people from the future, who
+  are looking for some quick context around this set of changes.
+
+  A great way to start is to follow <a href="https://github.com/jupyterhub/.github/tree/master/.github/ISSUE_TEMPLATE">issue templates</a> or the repository specific
+  PR template (if any). Ultimately, the most important question to answer in your
+  description is: *what goal do you want to achieve with this change?*.
 
   Thank you! :heart:
 

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,23 @@
+# Configuration for request-info - https://github.com/behaviorbot/request-info
+
+# *Required* Comment to reply with
+requestInfoReplyComment: |
+  Hi there :wave:!
+
+  We would appreciate it if you could provide us with more info about this issue/PR.
+  A great way to start would be to follow the <a href="https://github.com/jupyterhub/.github/tree/master/.github/ISSUE_TEMPLATE">issue templates</a> or the repository
+  specific PR template (if any).
+  
+  This helps people review your contribution and answer questions more quickly and also
+  people from the future who are looking for some quick context around this set of changes.
+
+  Thank you! :heart:
+
+# *OPTIONAL* default titles to check against for lack of descriptiveness
+# MUST BE ALL LOWERCASE
+requestInfoDefaultTitles:
+  - update readme.md
+  - updates
+
+# *OPTIONAL* Label to be added to Issues and Pull Requests with insufficient information given
+requestInfoLabelToAdd: needs-more-info

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -9,7 +9,7 @@ requestInfoReplyComment: |
   specific PR template (if any).
   
   This helps people review your contribution and answer questions more quickly and also
-  people from the future who are looking for some quick context around this set of changes.
+  helps people in the future who are looking for some quick context around this set of changes.
 
   Thank you! :heart:
 


### PR DESCRIPTION
Closes https://github.com/jupyterhub/.github/issues/2

When no description is provided for a issue/PR, the bot will label the issue with `needs-more-info` and post [this message](https://github.com/GeorgianaElena/.github/issues/9):
![req-info](https://user-images.githubusercontent.com/7579677/80470902-4fa53100-894b-11ea-937b-bdd704bf04be.png)

I couldn't link a PR template because we don't have an organization specific one yet.
Also, the bot doesn't provide any placeholder we can use to get the username of the person opening the issue/pr or the name of the repo.

