### PR TITLE
Add labels to issues based on the template they used

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F41B Bug report"
 about: Create a report to help us repair something that is currently broken
+labels: bug
 
 ---
 <!-- Thank you for contributing. These HTML commments will not render in the issue, but you can delete them once you've read them if you prefer! -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F680 Feature request"
 about: Suggest a new feature or a big change
+labels: enhancement
 
 ---
 <!-- Thank you for contributing. These HTML commments will not render in the issue, but you can delete them once you've read them if you prefer! -->


### PR DESCRIPTION
This should automatically add:
* a `bug` label to the issues opened using the bug issue template
* an `enhancement` label to the issues opened using the feature_request template

We will end up having issue with just 2 labels added, and issues with no label when a "blank issue" option is used. But this will help with spotting the support issues more easily (because they won't have any labels). We could manually label these to be taken care of the support bot.

What do you think? Is automatically adding these labels a good idea?