### PR TITLE
Fix typo in comment

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest a new feature or a big change
 labels: enhancement
 
 ---
-<!-- Thank you for contributing. These HTML commments will not render in the issue, but you can delete them once you've read them if you prefer! -->
+<!-- Thank you for contributing. These HTML comments will not render in the issue, but you can delete them once you've read them if you prefer! -->
 
 ### Proposed change
 <!-- Use this section to describe the feature you'd like to be added. -->


### PR DESCRIPTION
Minor typo spotted by the browser spell checker:

![image](https://user-images.githubusercontent.com/591645/86019478-f333c000-ba26-11ea-9f31-5417faa94735.png)
