### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+Thank you for contributing to this repository!
+
+You can help us review your changes by answering these questions.
+They are all optional, but the more information you provide the easier it will be for us to review your changes.
+Everyone here is a volunteer, so please help us out if you can.
+
+If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
+
+
+### What does this PR do?
+<!--
+Please summarise this PR.
+Please also edit the PR title so that it contains enough context to go into a changelog.
+Use "Fixes #<NUM>" if this fixes an existing issue.
+-->
+
+### List of changes
+<!--
+Outline the main changes proposed in this PR (pull-request).
+You can use bullet points "-" if it helps.
+-->
+- Change X
+- Add Y
+
+### Is this PR related to another issue, or is it part of a larger body of work?
+<!--
+Please feel free to provide as much context or links to external sites as you want!
+-->
+
+### Does this PR introduce a breaking change?
+<!--
+If so what changes might users need to make in their applications due to this PR?
+-->
+
+### How can this PR be tested?
+<!--
+If this is not fully covered by the automated tests please help us by showing us the steps needed to verify the changes work.
+-->
+
+### What should a reviewer concentrate their feedback on?
+<!--
+This section is particularly useful if you have a pull request that is still in development.
+You can guide the reviews to focus on the parts that are ready for their comments.
+You can use bullet points "-" if it helps.
+-->
+
+### Other information
+<!--
+Please provide any other information you think is relevant
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,15 +12,8 @@ If you want to discuss anything Jupyter related, or to meet other users and deve
 Please summarise this PR.
 Please also edit the PR title so that it contains enough context to go into a changelog.
 Use "Fixes #<NUM>" if this fixes an existing issue.
+It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
 -->
-
-### List of changes
-<!--
-Outline the main changes proposed in this PR (pull-request).
-You can use bullet points "-" if it helps.
--->
-- Change X
-- Add Y
 
 ### Is this PR related to another issue, or is it part of a larger body of work?
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!--
 Thank you for contributing to this repository!
 
 You can help us review your changes by answering these questions.
@@ -5,6 +6,7 @@ They are all optional, but the more information you provide the easier it will b
 Everyone here is a volunteer, so please help us out if you can.
 
 If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
+-->
 
 
 ### What does this PR do?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,15 +9,21 @@ If you want to discuss anything Jupyter related, or to meet other users and deve
 
 ### What does this PR do?
 <!--
-Please summarise this PR.
+Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
 Please also edit the PR title so that it contains enough context to go into a changelog.
-Use "Fixes #<NUM>" if this fixes an existing issue.
 It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
 -->
+Type of change:
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation
+- [ ] Other
 
 ### Is this PR related to an issue, or is it part of a larger body of work?
 <!--
 Please feel free to provide as much context or links to external sites as you want!
+Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
 -->
 
 ### Does this PR introduce a breaking change?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Use "Fixes #<NUM>" if this fixes an existing issue.
 It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
 -->
 
-### Is this PR related to another issue, or is it part of a larger body of work?
+### Is this PR related to an issue, or is it part of a larger body of work?
 <!--
 Please feel free to provide as much context or links to external sites as you want!
 -->
@@ -27,7 +27,7 @@ If so what changes might users need to make in their applications due to this PR
 
 ### How can this PR be tested?
 <!--
-If this is not fully covered by the automated tests please help us by showing us the steps needed to verify the changes work.
+If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
 -->
 
 ### What should a reviewer concentrate their feedback on?


### PR DESCRIPTION
This is a follow-up to https://github.com/jupyterhub/team-compass/issues/302 and also https://github.com/jupyterhub/repo2docker/issues/671, and partly related to https://github.com/jupyterhub/team-compass/issues/288

The aim of this template is to obtain more information from PR submitters to help us (and external contributers willing to help review!) understand the PR. It also attempts to deal with some concerns raised in https://github.com/jupyterhub/team-compass/issues/288 by encouraging people to give more context for their PR.

@trallard