### PR TITLE
New issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F41B Bug report"
 about: Create a report to help us repair something that is currently broken
-labels: bug
+labels: "needs: triage, bug"
 
 ---
 <!-- Thank you for contributing. These HTML commments will not render in the issue, but you can delete them once you've read them if you prefer! -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F680 Feature request"
 about: Suggest a new feature or a big change
-labels: enhancement
+labels: "needs: discussion, enhancement"
 
 ---
 <!-- Thank you for contributing. These HTML comments will not render in the issue, but you can delete them once you've read them if you prefer! -->

--- a/.github/ISSUE_TEMPLATE/not_working.md
+++ b/.github/ISSUE_TEMPLATE/not_working.md
@@ -1,0 +1,34 @@
+---
+name: "\U0001F494 Something is not working"
+about: When you're seeing errors and you're not sure if there are because of a bug, a missing feature, or a misconfiguration
+labels: "needs: triage, help wanted"
+
+---
+<!-- Thank you for contributing. These HTML commments will not render in the issue, but you can delete them once you've read them if you prefer! -->
+
+### Issue description
+<!-- Use this section to clearly and concisely describe what is not working. -->
+
+#### Expected behaviour
+<!-- Tell us what you thought would happen. -->
+
+#### Actual behaviour
+<!-- Tell us what actually happens. -->
+
+### How to reproduce
+<!-- Use this section to describe the steps that a user would take to experience this bug. -->
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Your personal set up
+<!-- Tell us a little about the system you're using. -->
+
+ - OS:
+ <!-- [e.g. linux, OSX] -->
+ - Version:
+ <!-- e.g. jupyterhub --version. --->
+ - Configuration:
+ <!-- Be careful not to share any sensitive information. --->


### PR DESCRIPTION
This adds some extra labels on new issues that use the issue templates:
- `needs: triage` for bug reports
- `needs: discussion` for feature requests

This PR also adds a **new issue template**, for problems that might not be super clear for the contributor if they happen because of a bug, a misconfiguration (and should be on Discourse) or just because of a missing feature.

I'm not sure at all if this is the way to go, but I think it might be a step towards implementing a more effective labeling system, that's sustainable and not based only on the bug-enhancement distinction, as @minrk nicely explained [here](https://github.com/jupyterhub/team-compass/issues/334#issuecomment-680879473).