### PR TITLE
config.yml: remove ref to PR template

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -52,7 +52,6 @@ newPRWelcomeComment: >
   Thanks for submitting your first pull request! You are awesome! :hugs:
 
   <br>If you haven't done so already, check out [Jupyter's Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md).
-  Also, please make sure you followed the pull request template, as this will help us review your contribution more quickly.
 
   ![welcome](https://raw.githubusercontent.com/jupyterhub/.github/master/images/welcome.jpg)
 


### PR DESCRIPTION
This config applies across the jupyterhub org, but not all repos have a PR template

See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3072#issuecomment-1489097638

Alternatively we could add a PR template .... we discussed this a few years ago https://github.com/jupyterhub/.github/pull/11 but given it's age may need changing.