### PR TITLE
Move 'how to repro' before behavior headings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,14 +10,6 @@ labels: bug
 
 <!-- Use this section to clearly and concisely describe the bug. -->
 
-#### Expected behaviour
-
-<!-- Tell us what you thought would happen. -->
-
-#### Actual behaviour
-
-<!-- Tell us what actually happens. -->
-
 ### How to reproduce
 
 <!-- Use this section to describe the steps that a user would take to experience this bug. -->
@@ -26,6 +18,14 @@ labels: bug
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+
+#### Expected behaviour
+
+<!-- Tell us what you thought would happen. -->
+
+#### Actual behaviour
+
+<!-- Tell us what actually happens. -->
 
 ### Your personal set up
 


### PR DESCRIPTION
I think it makes more sense for the flow to be:

1. What did you do? (how to repro)
2. What did you expect to happen, now that you have done it?
3. What happened instead?

Rather than the ordering being:

1. What did you expect to happen, now that you have done it?
2. What happened instead?
3. What did you do? (how to repro)

(Discovered while filing https://github.com/jupyterhub/jupyterhub/issues/4557)